### PR TITLE
Fixes issue where class is not rendered

### DIFF
--- a/src/BoltResponsiveImagesExtension.php
+++ b/src/BoltResponsiveImagesExtension.php
@@ -67,7 +67,7 @@ class BoltResponsiveImagesExtension extends SimpleExtension
 
 
         // if a class is set in the config or options pass it to the template
-        $htmlClass = $defaultOptions[ 'class' ];
+        $htmlClass[] = $defaultOptions[ 'class' ];
 
         // test for lazyload
 //        $lazy = $defaultOptions['lazyLoad'];


### PR DESCRIPTION
The class is not rendered in the template. The template expects an array.

Looking at the extensions class in PHP, i assumed the value is supposed to change to an array when newer functionalities come. That's how i came to my proposed solution.
